### PR TITLE
Fix to prevent naming collisions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ plugins {
 
 allprojects {
     group = "com.philo"
-    version = "0.1.0"
+    version = "0.1.1"
 
     repositories {
         mavenLocal()


### PR DESCRIPTION
Prepends parent class(es) to interface and function declarations to prevent naming collisions in the following scenario:

1. Create 2 top-level classes in the same package
2. Create an inner class with the same name in each class
3. Project does not compile because the generated code has a fully qualified name collision because the parent class names are not taken into account