### PR TITLE
Fix recompile issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,3 +177,13 @@ The most up to date dependencies can always be found in the module `build.gradle
 The main dependencies for this project include:
 - [KSP](https://github.com/google/ksp/tree/main) - [Apache 2.0](https://github.com/google/ksp/blob/main/LICENSE)
 - [KotlinPoet](https://github.com/square/kotlinpoet) - [Apache 2.0](https://github.com/square/kotlinpoet/blob/main/LICENSE.txt)
+
+## Building Locally
+To build and publish the library to your local Maven repository, run:
+```bash
+./gradlew -PskipSigning publishToMavenLocal
+```
+
+The `-PskipSigning` flag skips GPG signing, which is only required for publishing to Maven Central.
+
+The version published will be the one defined in the root `build.gradle.kts` file (currently set in `allprojects { version = "..." }`).

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 kotlin.mpp.stability.nowarn=true
 
-kotlinVersion=2.0.0
-kspVersion=2.0.0-1.0.22
+kotlinVersion=2.1.0
+kspVersion=2.1.0-1.0.29
 kotlinPoetVersion=1.17.0

--- a/jsnamedargs-annotations/build.gradle.kts
+++ b/jsnamedargs-annotations/build.gradle.kts
@@ -37,7 +37,9 @@ kotlin {
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
-    signAllPublications()
+    if (!project.hasProperty("skipSigning")) {
+        signAllPublications()
+    }
     pom {
         name.set(project.name)
         description.set("Philo's KMP plugin to generate JS style functions and classes")

--- a/jsnamedargs-compiler/build.gradle.kts
+++ b/jsnamedargs-compiler/build.gradle.kts
@@ -28,7 +28,9 @@ sourceSets.main {
 
 mavenPublishing {
     publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, automaticRelease = true)
-    signAllPublications()
+    if (!project.hasProperty("skipSigning")) {
+        signAllPublications()
+    }
     pom {
         name.set(project.name)
         description.set("Philo's KMP plugin to generate JS style functions and classes")

--- a/jsnamedargs-compiler/src/main/kotlin/com/philo/compiler/JsNamedArgsVisitor.kt
+++ b/jsnamedargs-compiler/src/main/kotlin/com/philo/compiler/JsNamedArgsVisitor.kt
@@ -156,7 +156,8 @@ class JsNamedArgsVisitor(
         receiver: TypeName?,
         function: KSFunctionDeclaration,
         typeParameters: List<KSTypeParameter>,
-        outerParentClassTypeName: TypeName? = null
+        outerParentClassTypeName: TypeName? = null,
+        originatingFile: com.google.devtools.ksp.symbol.KSFile? = function.containingFile
     ) {
         val packageName = function.packageName.asString()
         val parameters = function.parameters
@@ -226,7 +227,7 @@ class JsNamedArgsVisitor(
                 addAnnotation(SuppressDeprecationAnnotation)
             }.build()
 
-            fileSpec.writeTo(codeGenerator, false)
+            fileSpec.writeTo(codeGenerator, false, listOfNotNull(originatingFile))
         }
     }
 }


### PR DESCRIPTION
* Updates to Kotlin 2.1.0
* adds `skipSigning` flag for building locally
* Fixes issue on recompile. See details of issue below

```The issue was in JsNamedArgsVisitor.kt. When calling fileSpec.writeTo(), the code was not telling KSP which source files "originated" the generated output:
// Before - no source file dependencies trackedfileSpec.writeTo(codeGenerator, false)
The second parameter (aggregating = false) means the output is "isolating" — it depends on specific input files. But since no originating files were passed, KSP had no record of which source files caused the generated files. This breaks incremental compilation because:
On subsequent builds, KSP doesn't know the generated files are connected to your annotated source files
The generated files get excluded from the build output since KSP thinks they're "orphaned"```